### PR TITLE
add support for challenge response

### DIFF
--- a/cwm_worker_operator/deployer.py
+++ b/cwm_worker_operator/deployer.py
@@ -77,7 +77,11 @@ def deploy_worker(domains_config, deployer_metrics, deployments_manager, worker_
         for i, hostname in enumerate(volume_config.hostnames):
             nginx_hostname = {'id': i, 'name': hostname}
             if hostname in volume_config.hostname_certs:
-                nginx_hostname.update(pem=volume_config.hostname_certs[hostname]['pem'], key=volume_config.hostname_certs[hostname]['key'])
+                nginx_hostname.update(pem=volume_config.hostname_certs[hostname]['pem'],
+                                      key=volume_config.hostname_certs[hostname]['key'])
+            if hostname in volume_config.hostname_challenges:
+                nginx_hostname.update(cc_token=volume_config.hostname_challenges[hostname]['token'],
+                                      cc_payload=volume_config.hostname_challenges[hostname]['payload'])
             nginx_hostnames.append(nginx_hostname)
         minio['nginx'] = {
             'hostnames': nginx_hostnames,

--- a/cwm_worker_operator/domains_config.py
+++ b/cwm_worker_operator/domains_config.py
@@ -141,6 +141,7 @@ class VolumeConfig:
         self._last_update = data.get('__last_update')
         self.hostnames = []
         self.hostname_certs = {}
+        self.hostname_challenges = {}
         minio_extra_configs = data.get('minio_extra_configs', {})
         self.protocols_enabled = set()
         for protocol in minio_extra_configs.pop('protocols-enabled', ['http', 'https']):
@@ -153,6 +154,11 @@ class VolumeConfig:
                     self.hostname_certs[hostname['hostname']] = {
                         'key': "\n".join(hostname['certificate_key']),
                         'pem': "\n".join(hostname['certificate_pem'])
+                    }
+                if hostname.get('token') and hostname.get('payload'):
+                    self.hostname_challenges[hostname['hostname']] = {
+                        'token': hostname['token'],
+                        'payload': hostname['payload']
                     }
         self.client_id = data.get("client_id")
         self.secret = data.get("secret")

--- a/tests/test_domains_config.py
+++ b/tests/test_domains_config.py
@@ -457,3 +457,17 @@ def test_worker_last_clear_cache(domains_config):
     domains_config.set_worker_last_clear_cache(worker_id, dt)
     assert domains_config.get_worker_last_clear_cache(worker_id) == dt
     assert domains_config.keys.worker_last_clear_cache.get(worker_id) == b'20210701T101233'
+
+
+def test_get_volume_config_challenge_attributes(domains_config):
+    worker_id, hostname = 'worker1', 'worker1.com'
+    domains_config._cwm_api_volume_configs['id:{}'.format(worker_id)] = get_volume_config_dict(
+        worker_id=worker_id, hostname=hostname, with_ssl=True, additional_hostnames=[
+            {
+                'hostname': 'hostname2.com', 'payload': 'zzPAYLOADyy', 'token': 'aaTOKENbb'
+            }
+        ]
+    )
+    volume_config = domains_config.get_cwm_api_volume_config(worker_id=worker_id)
+    assert hostname not in volume_config.hostname_challenges
+    assert volume_config.hostname_challenges['hostname2.com'] == {'token': 'aaTOKENbb', 'payload': 'zzPAYLOADyy'}


### PR DESCRIPTION
To support Let's Encrypt certificate registration - add support for challenge response (related minio PR: https://github.com/CloudWebManage/cwm-worker-deployment-minio/pull/24)