### PR TITLE
Fix CLI docs formatting.

### DIFF
--- a/cwm_worker_operator/cli.py
+++ b/cwm_worker_operator/cli.py
@@ -4,7 +4,7 @@ import importlib
 import click
 
 
-@click.group(context_settings={'max_content_width': 200})
+@click.group()
 def main():
     pass
 
@@ -50,6 +50,7 @@ for daemon in [
         main.add_command(click.Group(
             name=daemon['name'],
             help=daemon_module.__doc__,
+            short_help=daemon_module.__doc__,
             commands={
                 'start_daemon': click.Command(
                     name='start_daemon',
@@ -77,7 +78,7 @@ if kubernetes_not_configured:
     print("WARNING! Kubernetes is not configured, some commands are not available", file=sys.stderr)
 
 
-@main.command()
+@main.command(short_help="Make a low-level API call to get cwm instance volume configuration")
 @click.argument('QUERY_PARAM')
 @click.argument('QUERY_VALUE')
 def cwm_api_volume_config_api_call(query_param, query_value):
@@ -90,7 +91,7 @@ def cwm_api_volume_config_api_call(query_param, query_value):
     print(json.dumps(CwmApiManager().volume_config_api_call(query_param, query_value)))
 
 
-@main.command()
+@main.command(short_help="Make an operator api call to get instance volume config from cache")
 @click.option('--force-update', is_flag=True, help='Ignore the cache and force update from CWM api')
 @click.option('--hostname')
 @click.option('--worker-id')
@@ -102,7 +103,7 @@ def get_cwm_api_volume_config(force_update=False, hostname=None, worker_id=None)
     print(domains_config.DomainsConfig().get_cwm_api_volume_config(force_update=force_update, hostname=hostname, worker_id=worker_id))
 
 
-@main.command()
+@main.command(short_help="Make a low-level CWM api call to get cwm instance updates in the given time-range")
 @click.option('--from-before-seconds')
 @click.option('--from-datetime')
 def get_cwm_updates(from_before_seconds, from_datetime):
@@ -125,13 +126,14 @@ def get_cwm_updates(from_before_seconds, from_datetime):
     print(']')
 
 
-@main.command()
+@main.command(short_help="Send aggregated metrics to CWM api for debugging")
 @click.argument('WORKER_ID')
 @click.argument('MINUTES_JSON')
 def send_agg_metrics(worker_id, minutes_json):
     """
     Send aggregated metrics to CWM api for debugging
 
+    \b
     Example minutes_json data ("t": "%Y%m%d%H%M%S"):
     [
         {


### PR DESCRIPTION
Fix CLI docs formatting.

- Reset default width i.e. 80 characters (same for shell commands)
- Avoid rewrap for preformatted snippets ([use `\b` before snippet](https://click.palletsprojects.com/en/8.0.x/documentation/#preventing-rewrapping))
- Use `short_help` along with `help` for commands (fixes truncation)

**Sample**

**cwm_worker_operator**

```shell
$ ./venv/bin/cwm_worker_operator --help
Usage: cwm_worker_operator [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  alerter                         Sends alerts (to Slack)
  cleaner                         Cleanup unused Minio cache data from nodes
  clear-cacher                    Handles requests for Nginx clear cache from
                                  users

  cwm-api-volume-config-api-call  Make a low-level API call to get cwm
                                  instance volume configuration

  deleter                         Deletes worker deployments
  deployer                        Deploys workers
  disk-usage-updater              Collects disk usage data for workers
  get-cwm-api-volume-config       Make an operator api call to get instance
                                  volume config from cache

  get-cwm-updates                 Make a low-level CWM api call to get cwm
                                  instance updates in the given time-range

  initializer                     Initializes requests to deploy workers (the
                                  first step in deployment process)

  metrics-updater                 Aggregates metric data from workers
  nodes-checker                   Checks nodes and updates DNS records
                                  accordingly
                                  
                                  It doesn't actually do any healthchecks
                                  itself, it just updates DNS records for all
                                  cluster worker nodes. Each worker node also
                                  gets an AWS Route53 healthcheck which does
                                  the actual healthcheck and removes it from
                                  DNS if it fails. The healthchecks check cwm-
                                  worker-ingress /healthz path, so if the
                                  ingress stops responding the node is removed
                                  from DNS.
                                  
                                  In addition to the DNS healthchecks, the
                                  cwm-worker-ingress checks redis key
                                  node:healthy, if key is missing the /healthz
                                  path returns an error. nodes_checker updates
                                  this redis key to true for all worker nodes
                                  and to false for any nodes which are not
                                  currently listed as worker nodes - so nodes
                                  which are removed will instantly stop
                                  serving.

  send-agg-metrics                Send aggregated metrics to CWM api for
                                  debugging

  updater                         Initiates updates for workers, also sends
                                  aggregated metrics to CWM

  waiter                          Waits for deployed workers to be available
  web-ui                          A web interfacte for debugging
```

**send-agg-metrics**

```shell
$ ./venv/bin/cwm_worker_operator send-agg-metrics --help
Usage: cwm_worker_operator send-agg-metrics [OPTIONS] WORKER_ID MINUTES_JSON

  Send aggregated metrics to CWM api for debugging

  Example minutes_json data ("t": "%Y%m%d%H%M%S"):
  [
      {
          "t": "20210825214533",
          "disk_usage_bytes": 100,
          "bytes_in": 200,
          "bytes_out": 300,
          "num_requests_in": 5,
          "num_requests_out": 10,
          "num_requests_misc": 15,
          "sum_cpu_seconds": 50,
          "ram_limit_bytes": 100
      }
  ]

Options:
  --help  Show this message and exit.
```

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>