### PR TITLE
throttler should not rely on volume config worker ids for hostnames

### DIFF
--- a/cwm_worker_operator/throttler.py
+++ b/cwm_worker_operator/throttler.py
@@ -69,10 +69,11 @@ def check_worker_throttle_expiry(domains_config, worker_id, now=None):
 
 
 def run_single_iteration(domains_config: DomainsConfig, now=None, **_):
-    for hostname in domains_config.keys.hostname_available.iterate_prefix_key_suffixes():
-        worker_id = domains_config.keys.volume_config_hostname_worker_id.get(hostname)
-        if worker_id:
-            check_worker_throttle(domains_config, worker_id.decode(), now)
+    checked_worker_ids = set()
+    for _, worker_id in domains_config.iterate_ingress_hostname_worker_ids():
+        if worker_id not in checked_worker_ids:
+            checked_worker_ids.add(worker_id)
+            check_worker_throttle(domains_config, worker_id, now)
     for worker_id in domains_config.keys.worker_throttled_expiry.iterate_prefix_key_suffixes():
         check_worker_throttle_expiry(domains_config, worker_id, now)
 

--- a/tests/test_domains_config.py
+++ b/tests/test_domains_config.py
@@ -558,3 +558,35 @@ def test_volume_config_invalid_zone_for_cluster(domains_config):
     assert not volume_config.is_valid_zone_for_cluster
     assert volume_config.gateway_updated_for_request_hostname == geo_hostname
     assert isinstance(volume_config.gateway, VolumeConfigGatewayTypeS3)
+
+
+def test_iterate_ingress_hostname_worker_ids(domains_config):
+    namespace_name_valid1, hostname_valid1 = 'cwm-worker-valid1', 'www.valid1.com'
+    domains_config.keys.hostname_ingress_hostname.set(hostname_valid1, json.dumps({
+        'http': f'minio-nginx.{namespace_name_valid1}.svc.cluster.local',
+        'https': f'minio-nginx.{namespace_name_valid1}.svc.cluster.local',
+    }))
+    hostname_valid1_2 = 'www.valid1-2.com'
+    domains_config.keys.hostname_ingress_hostname.set(hostname_valid1_2, json.dumps({
+        'http': f'minio-nginx.{namespace_name_valid1}.svc.cluster.local',
+        'https': f'minio-nginx.{namespace_name_valid1}.svc.cluster.local',
+    }))
+    namespace_name_valid2, hostname_valid2 = 'cwm-worker-valid2', 'www.valid2.com'
+    domains_config.keys.hostname_ingress_hostname.set(hostname_valid2, json.dumps({
+        'http': f'minio-nginx.{namespace_name_valid2}.svc.cluster.local',
+        'https': f'minio-nginx.{namespace_name_valid2}.svc.cluster.local',
+    }))
+    namespace_name_invalid1, hostname_invalid1 = 'cwm-worker-invalid1', 'www.invalid1.com'
+    domains_config.keys.hostname_ingress_hostname.set(hostname_invalid1, json.dumps({
+        'http': f'xxxminio-nginx.{namespace_name_invalid1}.svc.cluster.local',
+    }))
+    namespace_name_invalid2, hostname_invalid2 = 'cwm-worker-invalid2', 'www.invalid2.com'
+    domains_config.keys.hostname_ingress_hostname.set(hostname_invalid2, json.dumps({
+        'foo': 'bar',
+    }))
+    assert list(domains_config.iterate_ingress_hostname_worker_ids()) == [
+        # hostname         worker id
+        ('www.valid1.com', 'valid1'),
+        ('www.valid2.com', 'valid2'),
+        ('www.valid1-2.com', 'valid1')
+    ]


### PR DESCRIPTION
fix a problem in some cases due to dependency on volume config for throttler which is not always available

* added `iterate_ingress_hostname_worker_ids` function which allows to iterate over all the hostname/worker ids which are currently served by the ingress
* this is then used by the throttler to iterate over workers to check